### PR TITLE
export ISSUER_SEED to be used in burn token request

### DIFF
--- a/client/src/CreateForm.tsx
+++ b/client/src/CreateForm.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 // TODO this is ridiculous yes, but these are values from a standalone node so
 // aren't sensitive
-const ISSUER_SEED = 'sEdV7xTKH4B2XFyW9h4F3VSBYradsnQ'
+export const ISSUER_SEED = 'sEdV7xTKH4B2XFyW9h4F3VSBYradsnQ'
 const ISSUER_ADDRESS = 'rnvkNkdTzUmgkGcEUTXHChbC3YxhEonTsF'
 
 const CreateForm = ({ client, isConnected }: Props) => {

--- a/client/src/TokenShow.tsx
+++ b/client/src/TokenShow.tsx
@@ -62,9 +62,8 @@ const TokenShow = ({ client }: Props) => {
   }, [id])
 
   const signAndSend = async (transaction: TransactionJSON) => {
-    const secret = ISSUER_SEED
     const preparedTransaction = await client.prepareTransaction(transaction)
-    const signedTransaction = client.sign(preparedTransaction.txJSON, secret)
+    const signedTransaction = client.sign(preparedTransaction.txJSON, ISSUER_SEED)
     const transactionResponse = await client.request('submit', {
       tx_blob: signedTransaction.signedTransaction,
     })


### PR DESCRIPTION
ISSUER_SEED needs to be exported to be used in burn token request.